### PR TITLE
Milestone page tooltip label fix

### DIFF
--- a/src/app/clan/clan-milestones/clan-milestones.component.html
+++ b/src/app/clan/clan-milestones/clan-milestones.component.html
@@ -33,7 +33,7 @@
                             matTooltipClass="preserve-white-space">{{mileStoneName.name}}</span>
                         <span *ngIf="debugmode|async">  {{mileStoneName.key}}</span>
                         <span class="fake-link"
-                            matTooltip="Hide this milestone, click Show All to restore it later"
+                            matTooltip="Hide this milestone, click Restore Hidden to restore it later"
                             class="milestoneVisibilityButton" (click)="hideClanMilestone(mileStoneName.key)">
                             <fa-icon [icon]="iconService.falEyeSlash"></fa-icon>
                     </span>
@@ -104,7 +104,7 @@
                                 matTooltipClass="preserve-white-space">{{mileStoneName.name}}</span>
                             <span *ngIf="debugmode|async">  {{mileStoneName.key}}</span>
                             <span class="fake-link"
-                                matTooltip="Hide this milestone, click Show All to restore it later"
+                                matTooltip="Hide this milestone, click Restore Hidden to restore it later"
                                 class="milestoneVisibilityButton" (click)="hideClanMilestone(mileStoneName.key)">
                                 <fa-icon [icon]="iconService.falEyeSlash"></fa-icon>
                             </span>

--- a/src/app/friends/friends/friends.component.html
+++ b/src/app/friends/friends/friends.component.html
@@ -31,7 +31,7 @@
               *ngIf="(hiddenMilestones|async).indexOf(mileStoneName.key)===-1">
               {{mileStoneName.name}}
               <span *ngIf="debugmode|async">{{mileStoneName.key}}</span>
-              <span matTooltip="Hide this milestone, click Show All to restore it later"
+              <span matTooltip="Hide this milestone, click Restore Hidden to restore it later"
                 class="fake-link milestoneVisibilityButton" (click)="hideMilestone(mileStoneName.key)">
                 <fa-icon [icon]="iconService.falEyeSlash"></fa-icon>
               </span>
@@ -86,7 +86,7 @@
                 [attr.data-label]="mileStoneName.name">
 
                   <span class="fake-link" style="float: left"
-                    matTooltip="Hide this milestone, click Show All to restore it later"
+                    matTooltip="Hide this milestone, click Restore Hidden to restore it later"
                     class="mobileVisibilityButton responsive-table-inline-mobile-only"
                     (click)="hideMilestone(mileStoneName.key)">
                     <fa-icon [icon]="iconService.falEyeSlash"></fa-icon>

--- a/src/app/player/milestones/milestones.component.html
+++ b/src/app/player/milestones/milestones.component.html
@@ -70,7 +70,7 @@
                 </span>
                 <span *ngIf="debugmode|async" class="simple-caption-no-margin"> {{mileStoneName.key}}</span>
               </div>
-              <div class="fake-link" matTooltip="Hide this milestone, click Show All to restore it later"
+              <div class="fake-link" matTooltip="Hide this milestone, click Restore Hidden to restore it later"
                 class="hideMilestoneButton" (click)="hideMilestone(mileStoneName.key)">
                 <fa-icon [icon]="iconService.farTimes"></fa-icon>
               </div>


### PR DESCRIPTION
The button to restore hidden milestones on the milestone pages was updated in #296 from "Show All" to "Restore Hidden" and the tooltips weren't updated to illustrate the new text.

Minor text fix included on affected pages to ensure users understand the "Restore Hidden" behavior from tooltip text.