### PR TITLE
Fix Input Styles

### DIFF
--- a/src/app/bungie-search/bungie-search/bungie-search.component.html
+++ b/src/app/bungie-search/bungie-search/bungie-search.component.html
@@ -8,6 +8,7 @@
 
 <div>
   <mat-form-field class="searchField">
+    <mat-label>Bungie Name</mat-label>
     <input matInput placeholder="Bungie name" [(ngModel)]="name" (keyup.enter)="search()">
   </mat-form-field>
   &emsp;
@@ -27,7 +28,7 @@
       </tr>
     </thead>
     <tr *ngFor="let row of rows">
-      <td class="lead" data-label="Name">        
+      <td class="lead" data-label="Name">
         <a [routerLink]="['/', row.searchResult.membershipType, row.searchResult.membershipId]">
         <fa-icon [icon]="Const.PLATFORMS_DICT[row.searchResult.membershipType+''].icon"></fa-icon>
         {{row.bungieGlobalDisplayName}}

--- a/src/app/clan-search/clan-search/clan-search.component.html
+++ b/src/app/clan-search/clan-search/clan-search.component.html
@@ -6,6 +6,7 @@
 </div>
 <div>
   <mat-form-field class="searchField">
+    <mat-label>Clan Name</mat-label>
     <input matInput placeholder="Clan name" [(ngModel)]="name" (keyup.enter)="search()">
   </mat-form-field>
   &emsp;

--- a/src/app/clan/clan-collections/clan-collection-search/clan-collection-search.component.html
+++ b/src/app/clan/clan-collections/clan-collection-search/clan-collection-search.component.html
@@ -1,8 +1,9 @@
 <div *ngIf="filteredCollection|async as c" class="clan-collection-search">
         <div class="left" class="medium-margin">
             <mat-form-field class="searchField">
+                <mat-label>Wildcard Search Collections</mat-label>
                 <input matInput (keyup)="collectionSearchChange()" [(ngModel)]="collectionFilterText"
-                    placeholder="Wildcard Search collections">
+                    placeholder="Wildcard Search Collections">
             </mat-form-field>
         </div>
         <div *ngIf="c.length==0" class="left" class="medium-margin">

--- a/src/app/clan/clan-triumphs/clan-triumph-search/clan-triumph-search.component.html
+++ b/src/app/clan/clan-triumphs/clan-triumph-search/clan-triumph-search.component.html
@@ -1,8 +1,9 @@
 <div *ngIf="filteredTriumphs|async as t" class="clan-triumph-search">
     <div class="left" class="medium-margin">
         <mat-form-field class="searchField">
+            <mat-label>Wildcard Search Triumphs</mat-label>
             <input matInput (keyup)="triumphSearchChange()" [(ngModel)]="triumphFilterText"
-                placeholder="Wildcard Search triumphs">
+                placeholder="Wildcard Search Triumphs">
         </mat-form-field>
     </div>
     <div *ngIf="t.length==0" class="left" class="medium-margin">

--- a/src/app/gear/gear/gear-compare-dialog/gear-compare-dialog.component.html
+++ b/src/app/gear/gear/gear-compare-dialog/gear-compare-dialog.component.html
@@ -150,6 +150,7 @@
                     <ng-container *ngFor="let i of sortedItems|async">
                         <td *ngIf="shouldNotHide(i)" [ngClass]="i.mark?i.mark:'none'">
                             <mat-form-field class="full-width">
+                                <mat-label>Notes</mat-label>
                                 <input matInput placeholder="Notes" maxlength="100" [(ngModel)]="i.notes"
                                     placeholder="Notes" (ngModelChange)="parent.itemNotesChanged(i)"
                                     [matAutocomplete]="hashTagAuto">
@@ -158,13 +159,13 @@
                                 <div class="total-progress">
                                   <mat-progress-bar class="progress-bar progress-bar" color="warn" mode="determinate" [value]="obj.percent"></mat-progress-bar>
                                   <div class="simple-caption">{{obj.percent|number : '1.0-0'}}% Attuned</div>
-                                </div>                  
+                                </div>
                               </div>
                               <div *ngIf="i.craftProgress as obj" class="obj-desc">
                                 <div class="total-progress">
                                   <mat-progress-bar class="progress-bar progress-bar" color="accent" mode="determinate" [value]="obj.percent"></mat-progress-bar>
                                   <div class="simple-caption">{{obj.percent|number : '1.0-0'}}% To Level {{obj.level}}<br>{{obj.date|date:'shortDate'}}</div>
-                                </div>                  
+                                </div>
                               </div>
                         </td>
                     </ng-container>

--- a/src/app/gear/gear/gear.component.html
+++ b/src/app/gear/gear/gear.component.html
@@ -409,40 +409,40 @@
                     <fa-icon [icon]="iconService.fasEnvelope"></fa-icon>
                   </span>
                   <d2c-god-roll-item [item]="i" [debugmode]="debugmode|async"></d2c-god-roll-item>
-                </div>                
+                </div>
                 <div *ngIf="i.deepSightProgress as obj" class="obj-desc">
                   <div class="total-progress">
                     <mat-progress-bar class="progress-bar" color="warn" mode="determinate" [value]="obj.percent"></mat-progress-bar>
                     <div class="simple-caption">{{obj.percent|number : '1.0-0'}}% Attuned</div>
-                  </div>                  
+                  </div>
                 </div>
                 <div *ngIf="i.craftProgress as obj" class="obj-desc">
                   <div class="total-progress">
                     <mat-progress-bar class="progress-bar" color="accent" mode="determinate" [value]="obj.percent"></mat-progress-bar>
                     <div class="simple-caption">{{obj.percent|number : '1.0-0'}}% To Level {{obj.level}}<br>{{obj.date|date:'shortDate'}}</div>
-                  </div>                  
+                  </div>
                 </div>
-                
+
                 <ng-container *ngIf="i.patternTriumph as t">
                   <div *ngIf="t.percent<100" class="fake-link" [routerLink]="['/',player.profile.userInfo.membershipType, player.profile.userInfo.membershipId, 'triumphs','tree',t.hash]">
                     <div class="total-progress">
                       <mat-progress-bar class="progress-bar" color="accent" mode="determinate" [value]="t.percent"></mat-progress-bar>
                       <div class="simple-caption fake-link">{{t.percent|number : '1.0-0'}}% Recipe</div>
-                    </div>                  
+                    </div>
                   </div>
                   <div *ngIf="t.percent==100" class="margin-top-10 fake-link simple-caption" [routerLink]="['/',player.profile.userInfo.membershipType, player.profile.userInfo.membershipId, 'triumphs','tree',t.hash]">Recipe <fa-icon class="pad-left" [icon]="iconService.fasCheck"></fa-icon></div>
                 </ng-container>
-                
+
                 <ng-container *ngIf="i.exoticCatalystTriumph as t">
                   <div *ngIf="t.percent < 100" class="fake-link" [routerLink]="['/',player.profile.userInfo.membershipType, player.profile.userInfo.membershipId, 'triumphs','tree',t.hash]">
                     <div class="total-progress">
                       <mat-progress-bar class="progress-bar" color="accent" mode="determinate" [value]="t.percent"></mat-progress-bar>
                       <div class="simple-caption fake-link">{{t.percent|number : '1.0-0'}}% Catalyst</div>
-                    </div>                  
+                    </div>
                   </div>
                   <div *ngIf="t.percent==100" class="margin-top-10 fake-link simple-caption" [routerLink]="['/',player.profile.userInfo.membershipType, player.profile.userInfo.membershipId, 'triumphs','tree',t.hash]">Catalyst <fa-icon class="pad-left" [icon]="iconService.fasCheck"></fa-icon></div>
                 </ng-container>
-                
+
               </td>
               <td class="limited-gear-width hide-mobile-table-cell" *ngIf="option.type==ItemType.Weapon">
                 <ng-container *ngIf="i.powerCap<9999; else highCap">
@@ -475,7 +475,7 @@
 
               </td>
 
-              <td class="limited-gear-width" *ngIf="option.type==ItemType.Weapon || option.type==ItemType.Armor 
+              <td class="limited-gear-width" *ngIf="option.type==ItemType.Weapon || option.type==ItemType.Armor
               || option.type==ItemType.Ghost || option.type==ItemType.Vehicle">
                 <button mat-button (click)="showCopies(i)">
                   <fa-icon [icon]="iconService.falClone"></fa-icon> {{i.copies}}
@@ -511,7 +511,7 @@
 
               <td
                 *ngIf="option.type==ItemType.Weapon || option.type==ItemType.Vehicle">
-                <d2c-writable-sockets [item]="i" (socketsChanged)="changeDetection.detectChanges()"></d2c-writable-sockets>              
+                <d2c-writable-sockets [item]="i" (socketsChanged)="changeDetection.detectChanges()"></d2c-writable-sockets>
               </td>
               <td class="limited-gear-width"
                 *ngIf="option.type==ItemType.Armor">
@@ -562,15 +562,15 @@
                 <table class="stat-table" *ngIf="i.type==ItemType.Armor">
                   <tbody>
                     <ng-container *ngFor="let stat of i.stats">
-                      <ng-container *ngIf="preferredStatService.getMultiplierForDisplay(prefStats, ClassAllowed[i.classAllowed],stat) as prefStat"> 
+                      <ng-container *ngIf="preferredStatService.getMultiplierForDisplay(prefStats, ClassAllowed[i.classAllowed],stat) as prefStat">
                         <ng-container *ngIf="prefStat > 0 || prefStats.showAllStats">
                           <tr>
                             <td class="gear-sort">
-                              <span class="fake-link" 
-                              [matTooltip]="prefStat+'% weight'" 
+                              <span class="fake-link"
+                              [matTooltip]="prefStat+'% weight'"
                               [matTooltipDisabled]="prefStat <= 0"
                               [class.italics]="prefStat > 0 && prefStats.showAllStats"
-                              (click)="sort('stat.'+stat.hash)">{{stat.name}} 
+                              (click)="sort('stat.'+stat.hash)">{{stat.name}}
                                 <d2c-sort-indicator [field]="'stat.'+stat.hash" [currVal]="gearFilterStateService.sortBy$|async" [descending]="gearFilterStateService.sortDesc$|async">
                                 </d2c-sort-indicator>
                               </span>
@@ -581,7 +581,7 @@
                             </td>
                           </tr>
                         </ng-container>
-                      </ng-container> 
+                      </ng-container>
                     </ng-container>
                   </tbody>
                 </table>
@@ -612,6 +612,7 @@
                 </div>
                 <div>
                   <mat-form-field class="full-width">
+                    <mat-label>Notes</mat-label>
                     <input matInput placeholder="Notes" maxlength="100" [(ngModel)]="i.notes" placeholder="Notes"
                       (ngModelChange)="itemNotesChanged(i)" [matAutocomplete]="hashTagAuto">
                   </mat-form-field>

--- a/src/app/perkbench/perkbench.component.html
+++ b/src/app/perkbench/perkbench.component.html
@@ -4,6 +4,7 @@
             <mat-card-header class="align-left">
                 <mat-card-title>
                     <mat-form-field>
+                        <mat-label>Working Title</mat-label>
                         <input matInput [(ngModel)]="currentTitle" placeholder="Working Title">
                     </mat-form-field>
                 </mat-card-title>
@@ -98,6 +99,7 @@
                 <mat-button-toggle [value]="true">Console <fa-icon *ngIf="isController" class="pad-left" [icon]="iconService.fasCheck"></fa-icon></mat-button-toggle>
             </mat-button-toggle-group>
             <mat-form-field>
+                <mat-label>Wildcard Search</mat-label>
                 <input matInput (keyup)="filterChanged$.next(true)" [(ngModel)]="filterText"
                     placeholder="Wildcard Search">
             </mat-form-field>

--- a/src/app/player/collections/collection-search/collection-search.component.html
+++ b/src/app/player/collections/collection-search/collection-search.component.html
@@ -6,8 +6,9 @@
     <div>
       <div class="left" style="margin: 10px">
         <mat-form-field class="collection-search-field">
+          <mat-label>Wildcard Search Collections</mat-label>
           <input matInput (keyup)="searchSubject.next()" [(ngModel)]="filterText"
-            placeholder="Wildcard Search collections">
+            placeholder="Wildcard Search Collections">
         </mat-form-field>
       </div>
       <div *ngIf="fc.length==0" class="left" style="margin: 10px">
@@ -35,8 +36,8 @@
                 <div *ngIf="t.icon!=null" class="transparent-icon transparent-leaf-icon"
                   [style.background-image]="'url(//www.bungie.net' + t.icon + ')'"></div>
                 {{t.name}}
-                
-                <fa-icon [icon]="iconService.fasCheckSquare" *ngIf="t.acquired" class="accent-text mat-option.mat-selected"></fa-icon>                
+
+                <fa-icon [icon]="iconService.fasCheckSquare" *ngIf="t.acquired" class="accent-text mat-option.mat-selected"></fa-icon>
                 <fa-icon [icon]="iconService.farSquare" *ngIf="!t.acquired"></fa-icon>
                 <ng-container *ngIf="debugmode|async">{{t.hash}}</ng-container>
                 <br>

--- a/src/app/player/pursuits/pursuit-list/pursuit-list.component.html
+++ b/src/app/player/pursuits/pursuit-list/pursuit-list.component.html
@@ -11,6 +11,7 @@
       </mat-select>
     </mat-form-field>
     <mat-form-field class="searchField">
+      <mat-label>Search</mat-label>
       <input matInput (keyup)="searchSubject.next()" [(ngModel)]="displayFilterText" placeholder="Search">
       <button mat-button *ngIf="(realFilterText|async)!=null && (realFilterText|async).length>0" matSuffix
         mat-icon-button aria-label="Clear" (click)="displayFilterText=null;searchSubject.next()">

--- a/src/app/player/triumphs/triumph-search/triumph-search.component.html
+++ b/src/app/player/triumphs/triumph-search/triumph-search.component.html
@@ -2,10 +2,11 @@
     <div>
         <div class="left" style="margin: 10px">
             <mat-form-field class="searchField">
+                <mat-label>Wildcard Search Triumphs</mat-label>
                 <input matInput (keyup)="triumphSearchChange()" [(ngModel)]="triumphFilterText"
-                    placeholder="Wildcard Search triumphs">
+                    placeholder="Wildcard Search Triumphs">
             </mat-form-field>
-            <mat-checkbox class="hide-complete-triumphs" 
+            <mat-checkbox class="hide-complete-triumphs"
             [(ngModel)]="state.hideCompleteTriumphs"
             (change)="triumphSearchChange()"
             >

--- a/src/themes/black-theme.scss
+++ b/src/themes/black-theme.scss
@@ -13,6 +13,10 @@ $d2c-black-theme: mat.define-dark-theme($d2c-black-primary, $d2c-black-accent, $
         caret-color: white;
     }
 
+    mat-label {
+        color: white;
+    }
+
     .fake-link {
         color: #fff;
     }
@@ -37,7 +41,7 @@ $d2c-black-theme: mat.define-dark-theme($d2c-black-primary, $d2c-black-accent, $
         background-color: #303d4d;
     }
 
-    
+
     .mark-table>tbody>tr.none>td,
     .mark-table>tbody>tr>td.none {
         background-color: #212121;
@@ -49,7 +53,7 @@ $d2c-black-theme: mat.define-dark-theme($d2c-black-primary, $d2c-black-accent, $
         background-color: #344235;
     }
 
-    .mark-table>tbody>tr.infuse>td,    
+    .mark-table>tbody>tr.infuse>td,
     .mark-table>tbody>tr>td.infuse {
         background-color: #604532;
     }


### PR DESCRIPTION
This PR fixes the input styles on dark mode (text only, does not include select elements). Currently the label switches to dark text on a dark background **when the element is focused.** This PR switches to white instead of the default dark theme color. I also added the label elements so they were easier to select with CSS. This does not change the other themes.

Previous -
![image](https://user-images.githubusercontent.com/58316242/163066762-d32c2d26-86ed-45f5-8f2d-ac602c5c7284.png)

After Change -
![image](https://user-images.githubusercontent.com/58316242/163066696-c4e27c9e-4355-4019-8cd9-17ec212a11e3.png)
