### PR TITLE
Nightfall Season 20 Difficulty Adjustment

### DIFF
--- a/src/app/service/parse.service.ts
+++ b/src/app/service/parse.service.ts
@@ -1419,24 +1419,20 @@ export class ParseService {
             });
             for (const nfa of pmsa.nightfall.activities) {
                 if (nfa.name.endsWith('Grandmaster')) {
-                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP + 40)) {
-                        nfa.ll = Const.SEASON_PINNACLE_CAP + 40;
+                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP + 30)) {
+                        nfa.ll = Const.SEASON_PINNACLE_CAP + 30;
                     }
                 } else if (nfa.name.endsWith('Master')) {
-                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP + 20)) {
-                        nfa.ll = Const.SEASON_PINNACLE_CAP + 20;
+                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP + 30)) {
+                        nfa.ll = Const.SEASON_PINNACLE_CAP + 30;
                     }
                 } else if (nfa.name.endsWith('Legend')) {
-                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP - 10)) {
-                        nfa.ll = Const.SEASON_PINNACLE_CAP - 10;
+                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP + 20)) {
+                        nfa.ll = Const.SEASON_PINNACLE_CAP + 20;
                     }
                 } else if (nfa.name.endsWith('Hero')) {
                     if (nfa.ll < (Const.SEASON_PINNACLE_CAP - 40)) {
                         nfa.ll = Const.SEASON_PINNACLE_CAP - 40;
-                    }
-                } else if (nfa.name.endsWith('Adept')) {
-                    if (nfa.ll < (Const.SEASON_PINNACLE_CAP - 80)) {
-                        nfa.ll = Const.SEASON_PINNACLE_CAP - 80;
                     }
                 }
             }


### PR DESCRIPTION
In Season 20 the difficulty scaling of Destiny 2 was adjusted and the nightfall difficulty light levels were adjusted:

Adept OLD: 1730 (CAP-80)
Adept NEW: **REMOVED**

Hero OLD: 1770 (CAP-40)
Hero NEW: 1770 (CAP-40)

Legend OLD: 1810 (CAP-10)
Legend NEW: 1830 (CAP+20)

Master OLD: 1830 (CAP+20)
Master NEW: 1840 (CAP+30)

Grandmaster OLD: 1850 (CAP+40)
Grandmaster NEW: 1840 (CAP+30) **with additional modifiers**

(changes per Bringing Challenge Back article from Feb 23 https://www.bungie.net/7/en/News/article/bringing_challenge_back)

These code changes should update displayed light level for nightfalls pulled from the weekly milestone API and feed to any display location.