### PR TITLE
Fix typos in privacy component

### DIFF
--- a/src/app/privacy/privacy.component.html
+++ b/src/app/privacy/privacy.component.html
@@ -2,7 +2,7 @@
     <h1>Privacy Policy</h1>
     <p>
         The privacy of our visitors to D2Checklist is important to us for two big reasons. One: we have no interest in
-        invading your privacy. Two: we don't want to get break any laws, regulations, etc. In short D2Checklist: 
+        invading your privacy. Two: we don't want to break any laws, regulations, etc. In short D2Checklist: 
     </p>
     <ul>
         <li>Does not directly knowingly save any personally identifying information from users. Users logon directly via the (unaffiliated) Bungie API.</li>
@@ -30,7 +30,7 @@
     <p>For a better experience while using our Service, we may require you to provide us with certain personally
         identifiable information, including but not limited to your name, phone number, and postal address. The
         information
-        that we collect will be used to contact or identify you.</p>
+        that we collect will not be used to contact or identify you.</p>
 
     <h2>Log Data</h2>
 
@@ -44,7 +44,7 @@
 
     <h2>Cookies</h2>
 
-    <p>Cookies are files with small amount of data that is commonly used an anonymous unique identifier. These are sent
+    <p>Cookies are files with small amounts of data that are commonly used as an anonymous unique identifier. These are sent
         to
         your browser from the website that you visit and are stored on your computer’s hard drive.</p>
 
@@ -153,7 +153,7 @@
                 </ul>
             </li>
         </ul>
-        <h2>Non-Discrimintation</h2>
+        <h2>Non-Discrimination</h2>
         <p>We will not discriminate against you for exercising any of your CCPA rights. Unless permitted by the CCPA, we
             will
             not: </p>


### PR DESCRIPTION
This page might still be worth a closer review at some point -- you may consider swapping the apostrophe characters with single quotes, and the line breaks are a little odd.  Didn't want to roll editorial changes like that into this PR though.