### PR TITLE
Make craftedWildCardFilter use CSV and add popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2-checklist",
-  "version": "24.3.4",
-  "manifest": "226472.24.06.26.1731-1-bnet.56090",
+  "version": "24.2.3",
+  "manifest": "226342.24.06.19.1730-2-bnet.56014",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-checklist",
-  "version": "24.2.3",
+  "version": "24.3.5",
   "manifest": "226342.24.06.19.1730-2-bnet.56014",
   "license": "MIT",
   "scripts": {

--- a/src/app/player/triumphs/special-triumph-list/special-triumph-list.component.html
+++ b/src/app/player/triumphs/special-triumph-list/special-triumph-list.component.html
@@ -9,7 +9,7 @@
                     </mat-checkbox>
                 </ng-container>
                 <ng-container *ngIf="o.showCrafted">
-                    
+
                     <mat-form-field class="margin-left-10">
                         <mat-label>Filter</mat-label>
                         <mat-select [(ngModel)]="craftedFilter">
@@ -20,9 +20,20 @@
 
                         </mat-select>
                     </mat-form-field>
-                    <mat-form-field class="margin-left-10">
-                        <mat-label>Search Patterns By Name</mat-label>
-                        <input matInput [(ngModel)]="craftedWildCardFilter" placeholder="Search Patterns By Name">
+                    <mat-form-field class="margin-left-10" [style.width.px]=375>
+                        <mat-label>Search Patterns By Name (single or comma separated names)</mat-label>
+                        <input matInput [(ngModel)]="craftedWildCardFilter" [matAutocomplete]="auto" type="text"
+                            placeholder="Search Patterns By Name (single or comma separated names)">
+                        <button mat-button *ngIf="craftedWildCardFilter" matSuffix mat-icon-button aria-label="Clear"
+                            (click)="craftedWildCardFilter=''">
+                            <mat-icon>close</mat-icon>
+                        </button>
+                        <mat-autocomplete #auto="matAutocomplete">
+                            <mat-option *ngFor="let i of craftedWildCardFilterChoice" [value]="i.value"
+                                [disabled]="i.value==null">
+                                {{i.name}}
+                            </mat-option>
+                        </mat-autocomplete>
                     </mat-form-field>
                 </ng-container>
             </h4>
@@ -77,12 +88,12 @@
                                                                         class="normal-weight">Level {{obj.level}}</span>:
                                                                     {{obj.percent|number : '1.0-0'}}% tnl
                                                                     <br>{{obj.date|date:'shortDate'}}</div>
-                                                            </div>                                                        
+                                                            </div>
                                                         </div>
                                                     </ng-container>
                                                 </div>
                                                 <div *ngIf="!t.complete && t.redborder.length>0">
-                                                    <span class="crafted-text">{{t.redborder.length}} Deepsight held to attune.</span>                                                    
+                                                    <span class="crafted-text">{{t.redborder.length}} Deepsight held to attune.</span>
                                                 </div>
                                             </ng-container>
                                         </div>

--- a/src/app/player/triumphs/special-triumph-list/special-triumph-list.component.ts
+++ b/src/app/player/triumphs/special-triumph-list/special-triumph-list.component.ts
@@ -52,6 +52,16 @@ export class SpecialTriumphListComponent extends ChildComponent {
   public showCrafted$: BehaviorSubject<boolean> = new BehaviorSubject(false);
   public craftedFilter = 'TODO';
   public craftedWildCardFilter = '';
+  public craftedWildCardFilterChoice = [
+    {
+      name: 'current seasonal',
+      value: 'LOST SIGNAL,ILL OMEN,FAITH-KEEPER,TIMEWORN WAYFARER,VEILED THREAT,SIGHTLINE SURVEY',
+    },
+    {
+      name: 'ghost',
+      value: 'THE CALL,NO HESITATION,SOMEDAY,EMBRACED IDENTITY,PRO MEMORIA,FALSE IDOLS,BOLD ENDINGS,AXIAL LACUNA',
+    }
+  ]
   public craftedFilterChoices = [
     {
       name: 'Todo (Not Crafted + Incomplete)',
@@ -120,7 +130,14 @@ export class SpecialTriumphListComponent extends ChildComponent {
     if (this.craftedWildCardFilter == '') {
       return true;
     }
-    return t.name.toLowerCase().includes(this.craftedWildCardFilter.toLowerCase());
+    var found = false
+    for (const [_, value] of this.craftedWildCardFilter.toLowerCase().split(",").entries()) {
+      if (value != '' && t.name.toLowerCase().includes(value)) {
+        found = true
+        break
+      }
+    }
+    return found
   }
 
   public shouldShow(t: TriumphRecordNode): boolean {    


### PR DESCRIPTION
### Changes
- Modified filterPatternName so it can accept comma separated values. This will allow the user to enter specific names such as "THE CALL" or multiple values such as "THE CALL,NO HESITATION". Note that the input is always lowercased for comparisons.
- make the user interface include a popup that allows default values for the craftedWildCardFilter. Also include a button to clear the field. Make the text field a bit wider to more easily enter multiple values.
- populate craftedWildCardFilter popup menu with "current seasonal" and "ghost" options.
- update package.json version number

Default with no filter set:
![image](https://github.com/dcaslin/d2-checklist/assets/30057902/83681987-effd-47f2-8c29-8d8b0afab321)

Drop down with no selection yet made:
![image](https://github.com/dcaslin/d2-checklist/assets/30057902/64b99aa7-c149-4d04-8397-de016533d787)

"Current Seasonal Selected" (note the clear button is now present and the weapon list changed)
![image](https://github.com/dcaslin/d2-checklist/assets/30057902/72bedcd7-72c8-4cc4-84ea-59e7bb3ed625)

### Discussion:
I thought that I could take the initial idea of having a filter for the names and add the ability to handle comma separated values for the weapon names so you can see multiples at one time (while still allowing a single weapon to be shown if desired). I then took that further by adding the drop down for "well known" weapon groupings. This could contain any values we want here.

I think this satisfies what I was looking for, but I am open to making whatever changes you want here. 