### PR TITLE
Convert clan-state.service BehaviorSubjects to Angular signals

### DIFF
--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -108,14 +108,19 @@ Remaining:
 
 ## Phase 6: Further Signal Adoption
 
-274 `BehaviorSubject` instances across 52 files. Some already converted to signals.
+Started at 177 `BehaviorSubject` instances across 52 files.
 
-Priority conversions:
-- [ ] `gear-filter-state.service.ts` (45 BehaviorSubjects)
-- [ ] `uber-list-state.service.ts` (28 BehaviorSubjects)
-- [ ] `clan-state.service.ts` (18 BehaviorSubjects)
-- [ ] Evaluate Angular 19 signal APIs (`resource()`, `linkedSignal()`) after Phase 2
-- [ ] Convert incrementally, one service per PR
+Completed (PR #1):
+- [x] `clan-state.service.ts` — converted 17 BehaviorSubjects to signals, updated 16 consumer components/templates
+  - Service: `.next()` → `.set()`, `.getValue()` → `()`
+  - Templates: removed `| async` pipe, use direct signal call `()`
+  - Components: replaced `.subscribe()` with `effect()`, converted local BehaviorSubjects to signals
+
+Remaining:
+- [ ] `gear-filter-state.service.ts` (23 BehaviorSubjects)
+- [ ] `uber-list-state.service.ts` (17 BehaviorSubjects)
+- [ ] Evaluate Angular 19 signal APIs (`resource()`, `linkedSignal()`)
+- [ ] Convert remaining services incrementally, one per PR
 
 **Done when:** BehaviorSubject count under 150. The three largest files are converted.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-checklist",
-  "version": "30.1.0",
+  "version": "30.2.0",
   "manifest": "242999.26.03.25.2000-1-bnet.64463",
   "license": "MIT",
   "scripts": {

--- a/src/app/clan/clan-collections/clan-badges/clan-badges.component.html
+++ b/src/app/clan/clan-collections/clan-badges/clan-badges.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="state.badges|async as badges">
+<ng-container *ngIf="state.badges() as badges">
     <div class="badge-list">
         <ng-container *ngFor="let badge of badges">
 

--- a/src/app/clan/clan-collections/clan-badges/clan-badges.component.ts
+++ b/src/app/clan/clan-collections/clan-badges/clan-badges.component.ts
@@ -3,7 +3,7 @@ import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { ClanBadge, ClanStateService } from '@app/clan/clan-state.service';
 import { ChildComponent } from '@app/shared/child.component';
 import { ClanCollectionBadgeDialogComponent } from '../clan-collection-badge-dialog/clan-collection-badge-dialog.component';
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { NgIf, NgFor } from '@angular/common';
 import { MatButton } from '@angular/material/button';
 
 @Component({
@@ -11,7 +11,7 @@ import { MatButton } from '@angular/material/button';
     selector: 'd2c-clan-badges',
     templateUrl: './clan-badges.component.html',
     styleUrls: ['./clan-badges.component.scss'],
-    imports: [NgIf, NgFor, MatButton, AsyncPipe]
+    imports: [NgIf, NgFor, MatButton]
 })
 export class ClanBadgesComponent extends ChildComponent {
 

--- a/src/app/clan/clan-collections/clan-collection-search/clan-collection-search.component.html
+++ b/src/app/clan/clan-collections/clan-collection-search/clan-collection-search.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="filteredCollection|async as c" class="clan-collection-search">
+<div *ngIf="filteredCollection() as c" class="clan-collection-search">
         <div class="left" class="medium-margin">
             <mat-form-field class="searchField">
                 <mat-label>Wildcard Search Collections</mat-label>

--- a/src/app/clan/clan-collections/clan-collection-search/clan-collection-search.component.ts
+++ b/src/app/clan/clan-collections/clan-collection-search/clan-collection-search.component.ts
@@ -1,10 +1,10 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { ClanSearchableTriumph, ClanStateService } from '@app/clan/clan-state.service';
+import { ChangeDetectionStrategy, Component, effect, OnInit, signal } from '@angular/core';
+import { ClanSearchableCollection, ClanStateService } from '@app/clan/clan-state.service';
 import { ChildComponent } from '@app/shared/child.component';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { NgIf, NgFor } from '@angular/common';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
@@ -15,47 +15,47 @@ import { ClanCollectionItemComponent } from '../clan-collection-item/clan-collec
     selector: 'd2c-clan-collection-search',
     templateUrl: './clan-collection-search.component.html',
     styleUrls: ['./clan-collection-search.component.scss'],
-    imports: [NgIf, MatFormField, MatLabel, MatInput, FormsModule, NgFor, ClanCollectionItemComponent, AsyncPipe]
+    imports: [NgIf, MatFormField, MatLabel, MatInput, FormsModule, NgFor, ClanCollectionItemComponent]
 })
 export class ClanCollectionSearchComponent extends ChildComponent implements OnInit {
   private collectionSearchSubject: Subject<void> = new Subject<void>();
   public collectionFilterText: string | null = null;
-  public filteredCollection: BehaviorSubject<ClanSearchableTriumph[]> = new BehaviorSubject<ClanSearchableTriumph[]>([]);
+  public filteredCollection = signal<ClanSearchableCollection[]>([]);
 
   constructor(public state: ClanStateService) {
     super();
     this.collectionFilterText = localStorage.getItem('collection-filter');
+    effect(() => {
+      const _collections = this.state.searchableCollection();
+      this.filterCollections();
+    });
   }
 
   ngOnInit() {
-    this.state.searchableTriumphs.pipe(
-      takeUntilDestroyed(this.destroyRef)).subscribe(p => {
-        this.filterTriumphs();
-      });
     this.collectionSearchSubject.pipe(
       takeUntilDestroyed(this.destroyRef),
       debounceTime(50))
       .subscribe(() => {
         const saveMe = this.collectionFilterText == null ? null : this.collectionFilterText.toLowerCase();
         localStorage.setItem('collection-filter', saveMe!);
-        this.filterTriumphs();
+        this.filterCollections();
       });
   }
   collectionSearchChange() {
     this.collectionSearchSubject.next();
   }
 
-  private filterTriumphs() {
-    const searchableCollection = this.state.searchableCollection.getValue();
+  private filterCollections() {
+    const searchableCollection = this.state.searchableCollection();
     if (this.collectionFilterText == null || this.collectionFilterText.trim().length == 0) {
-      this.filteredCollection.next([]);
+      this.filteredCollection.set([]);
       return;
     }
     if (searchableCollection == null) {
-      this.filteredCollection.next([]);
+      this.filteredCollection.set([]);
       return;
     }
-    const temp = [];
+    const temp: ClanSearchableCollection[] = [];
     const filterText = this.collectionFilterText.toLowerCase();
     for (const t of searchableCollection) {
       if (temp.length > 20) { break; }
@@ -63,7 +63,7 @@ export class ClanCollectionSearchComponent extends ChildComponent implements OnI
         temp.push(t);
       }
     }
-    this.filteredCollection.next(temp as any);
+    this.filteredCollection.set(temp);
   }
 
 }

--- a/src/app/clan/clan-collections/clan-collections.component.html
+++ b/src/app/clan/clan-collections/clan-collections.component.html
@@ -7,7 +7,7 @@
     </a>
 </nav>
 <mat-tab-nav-panel #tabPanel>
-  <ng-container *ngIf="state.allLoaded|async; else notLoaded">
+  <ng-container *ngIf="state.allLoaded(); else notLoaded">
       <router-outlet></router-outlet>
   </ng-container>
 </mat-tab-nav-panel>

--- a/src/app/clan/clan-collections/clan-collections.component.ts
+++ b/src/app/clan/clan-collections/clan-collections.component.ts
@@ -5,14 +5,14 @@ import { ClanStateService } from '../clan-state.service';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { NgIf, AsyncPipe } from '@angular/common';
+import { NgIf } from '@angular/common';
 
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'd2c-clan-collections',
     templateUrl: './clan-collections.component.html',
     styleUrls: ['./clan-collections.component.scss'],
-    imports: [MatTabNav, MatTabLink, RouterLink, RouterLinkActive, FaIconComponent, MatTabNavPanel, NgIf, RouterOutlet, AsyncPipe]
+    imports: [MatTabNav, MatTabLink, RouterLink, RouterLinkActive, FaIconComponent, MatTabNavPanel, NgIf, RouterOutlet]
 })
 export class ClanCollectionsComponent extends ChildComponent {
 

--- a/src/app/clan/clan-info/clan-info.component.html
+++ b/src/app/clan/clan-info/clan-info.component.html
@@ -1,11 +1,11 @@
-<div class="body" *ngIf="state.info|async as info">
+<div class="body" *ngIf="state.info() as info">
 
     <h3>Progress</h3>
     <div class="section" *ngIf="info.primaryProgression!=null">
 
         <div class="row">
             <div class="col-sm-12 col-md-6">
-                <div class="clan-progress-row" *ngIf="state.modelPlayer|async as modelPlayer ; else loadingModel">
+                <div class="clan-progress-row" *ngIf="state.modelPlayer() as modelPlayer ; else loadingModel">
                     <span style="margin-right: 0.5em" *ngFor="let clanMs of modelPlayer.characters[0].clanMilestones">
                         {{clanMs.name}}
                         <fa-icon *ngIf="clanMs.earned==true" class="accent-text mat-option.mat-selected" [icon]="iconService.fasCheckSquare"></fa-icon>
@@ -20,8 +20,8 @@
             </div>
             <div class="col-sm-12 col-md-6">
                 <div class="clan-progress-row">
-                    <button mat-stroked-button [disabled]="(state.allLoaded|async) === false" (click)="state.downloadCsvReport()">
-                        <fa-icon [hidden]="state.allLoaded|async" [icon]="iconService.farSpinner" animation="spin-pulse" [fixedWidth]="true"></fa-icon>
+                    <button mat-stroked-button [disabled]="state.allLoaded() === false" (click)="state.downloadCsvReport()">
+                        <fa-icon [hidden]="state.allLoaded()" [icon]="iconService.farSpinner" animation="spin-pulse" [fixedWidth]="true"></fa-icon>
                         <fa-icon [icon]="iconService.falDownload"></fa-icon> Download CSV Report</button>
                 </div>
             </div>
@@ -70,7 +70,7 @@
                 </th>
             </thead>
             <tbody>
-                <tr *ngFor="let member of members|async">
+                <tr *ngFor="let member of members()">
                     <td>
                         <a [routerLink]="['/',member.destinyUserInfo.membershipType, member.destinyUserInfo.membershipId]">
                             {{member.destinyUserInfo.displayName}} {{member.destinyUserInfo.platformName}}

--- a/src/app/clan/clan-info/clan-info.component.ts
+++ b/src/app/clan/clan-info/clan-info.component.ts
@@ -1,12 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, signal } from '@angular/core';
 import { IconService } from '@app/service/icon.service';
 import { BungieGroupMember, Sort } from '@app/service/model';
 import { ChildComponent } from '@app/shared/child.component';
-import { BehaviorSubject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { ClanStateService } from '../clan-state.service';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NgIf, NgFor, AsyncPipe, DecimalPipe, DatePipe } from '@angular/common';
+import { NgIf, NgFor, DecimalPipe, DatePipe } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatButton } from '@angular/material/button';
 import { RouterLink } from '@angular/router';
@@ -18,7 +15,7 @@ import { AgoHumanizedPipe, DateFormatPipe } from '../../shared/pipe/timing.pipe'
     selector: 'd2c-clan-info',
     templateUrl: './clan-info.component.html',
     styleUrls: ['./clan-info.component.scss'],
-    imports: [NgIf, NgFor, FaIconComponent, MatButton, RouterLink, MatTooltip, AgoHumanizedPipe, DateFormatPipe, AsyncPipe, DecimalPipe, DatePipe]
+    imports: [NgIf, NgFor, FaIconComponent, MatButton, RouterLink, MatTooltip, AgoHumanizedPipe, DateFormatPipe, DecimalPipe, DatePipe]
 })
 export class ClanInfoComponent extends ChildComponent {
   sort: Sort = {
@@ -26,7 +23,7 @@ export class ClanInfoComponent extends ChildComponent {
     ascending: true
   };
 
-  public members: BehaviorSubject<BungieGroupMember[]> = new BehaviorSubject<BungieGroupMember[]>([]);
+  public members = signal<BungieGroupMember[]>([]);
 
   private static sortMembers(members: BungieGroupMember[], sort: Sort) {
     const modifier = sort.ascending ? 1 : -1;
@@ -74,24 +71,22 @@ export class ClanInfoComponent extends ChildComponent {
       this.sort.ascending = true;
       this.sort.name = field;
     }
-    this.applySort(this.members.getValue());
-
+    this.applySort(this.members().slice(0));
   }
 
 
   private applySort(m: BungieGroupMember[]) {
     ClanInfoComponent.sortMembers(m, this.sort);
-    this.members.next(m);
+    this.members.set(m);
   }
 
   constructor(public iconService: IconService,
     public state: ClanStateService) {
     super();
-    this.state.rawMembers.pipe(
-      takeUntilDestroyed(this.destroyRef))
-      .subscribe((rawMembers) => {
-        this.applySort(rawMembers.slice(0));
-      });
+    effect(() => {
+      const rawMembers = this.state.rawMembers();
+      this.applySort(rawMembers.slice(0));
+    });
   }
 
 }

--- a/src/app/clan/clan-lifetime/clan-lifetime.component.html
+++ b/src/app/clan/clan-lifetime/clan-lifetime.component.html
@@ -1,8 +1,8 @@
-<ng-container *ngIf="(state.aggHistoryAllLoaded|async) === false">
-    <p>Loading lifetime data for clan members. <ng-container *ngIf="state.sweepMsg|async as msg">{{msg}}</ng-container>
-        <span *ngIf="state.aggHistoryLoadCount|async as cnt">{{cnt}} / {{(state.sortedMembers|async)!.length}}</span>
+<ng-container *ngIf="state.aggHistoryAllLoaded() === false">
+    <p>Loading lifetime data for clan members. <ng-container *ngIf="state.sweepMsg() as msg">{{msg}}</ng-container>
+        <span *ngIf="state.aggHistoryLoadCount() as cnt">{{cnt}} / {{state.sortedMembers()!.length}}</span>
     </p>
-    <mat-progress-bar mode="determinate" [value]="(state.aggHistoryLoaded|async)!*100"></mat-progress-bar>
+    <mat-progress-bar mode="determinate" [value]="state.aggHistoryLoaded()!*100"></mat-progress-bar>
     <div class="center-spinner">
         <mat-spinner class="loading" class="center-spinner" *ngIf="(state.loading())===true">
         </mat-spinner>
@@ -10,7 +10,7 @@
 </ng-container>
 
 
-<div class="body" *ngIf="state.aggHistory|async as history">
+<div class="body" *ngIf="state.aggHistory() as history">
     <mat-tab-group>
         <mat-tab label="Raids">
             <ng-container *ngTemplateOutlet="aggTable; context: {type: 'raid', history: history}">

--- a/src/app/clan/clan-lifetime/clan-lifetime.component.ts
+++ b/src/app/clan/clan-lifetime/clan-lifetime.component.ts
@@ -1,13 +1,11 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, effect } from '@angular/core';
 import { ChildComponent } from '@app/shared/child.component';
 import { ClanStateService, ClanAggHistoryEntry } from '../clan-state.service';
-import { distinctUntilChanged, filter, takeUntil } from 'rxjs/operators';
 import { MatDialogConfig, MatDialog } from '@angular/material/dialog';
 import { ClanLifetimeDialogComponent } from './clan-lifetime-dialog/clan-lifetime-dialog.component';
 import { ClanUserListDialogComponent } from '../clan-settings/clan-user-list-dialog/clan-user-list-dialog.component';
 import { IconService } from '@app/service/icon.service';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NgIf, NgTemplateOutlet, NgFor, AsyncPipe, DecimalPipe } from '@angular/common';
+import { NgIf, NgTemplateOutlet, NgFor, DecimalPipe } from '@angular/common';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatTabGroup, MatTab } from '@angular/material/tabs';
@@ -22,26 +20,24 @@ import { TimingPipe } from '../../shared/pipe/timing.pipe';
     selector: 'd2c-clan-lifetime',
     templateUrl: './clan-lifetime.component.html',
     styleUrls: ['./clan-lifetime.component.scss'],
-    imports: [NgIf, MatProgressBar, MatProgressSpinner, MatTabGroup, MatTab, NgTemplateOutlet, NgFor, MatButton, MatTooltip, FaIconComponent, RouterLink, TimingPipe, AsyncPipe, DecimalPipe]
+    imports: [NgIf, MatProgressBar, MatProgressSpinner, MatTabGroup, MatTab, NgTemplateOutlet, NgFor, MatButton, MatTooltip, FaIconComponent, RouterLink, TimingPipe, DecimalPipe]
 })
-export class ClanLifetimeComponent extends ChildComponent implements OnInit {
+export class ClanLifetimeComponent extends ChildComponent {
+  private aggHistoryTriggered = false;
 
   constructor(public iconService: IconService,
     public state: ClanStateService,
     public dialog: MatDialog) {
     super();
+    effect(() => {
+      const allLoaded = this.state.allLoaded();
+      if (allLoaded && !this.aggHistoryTriggered) {
+        this.aggHistoryTriggered = true;
+        this.state.loadAggHistory();
+      }
+    });
   }
 
-  ngOnInit() {
-    this.state.allLoaded.pipe(
-      takeUntilDestroyed(this.destroyRef),
-      distinctUntilChanged(),
-      filter(x => x)
-      )
-      .subscribe((done: boolean) => {
-          this.state.loadAggHistory();
-      });
-  }
 
 
 

--- a/src/app/clan/clan-members/clan-members.component.html
+++ b/src/app/clan/clan-members/clan-members.component.html
@@ -1,15 +1,15 @@
-<ng-container *ngIf="state.modelPlayer|async as modelPlayer; else loadingModel">
-    <h4 *ngIf="(state.sortedMembers|async)!.length==0" class="left warn-text">
+<ng-container *ngIf="state.modelPlayer() as modelPlayer; else loadingModel">
+    <h4 *ngIf="state.sortedMembers()!.length==0" class="left warn-text">
         All members filtered out, check your <a routerLink="../settings">Settings</a>
     </h4>
-    <table class="tidy-auto-table clan-table" *ngIf="(state.sortedMembers|async)!.length>0">
+    <table class="tidy-auto-table clan-table" *ngIf="state.sortedMembers()!.length>0">
         <thead>
             <tr>
                 <ng-container *ngTemplateOutlet="sortHeader"></ng-container>
             </tr>
         </thead>
         <tbody>
-            <tr *ngFor="let member of state.sortedMembers|async">
+            <tr *ngFor="let member of state.sortedMembers()">
                 <td class="lead">
                     <a [routerLink]="['/',member.destinyUserInfo.membershipType, member.destinyUserInfo.membershipId]">
                         {{member.destinyUserInfo.displayName}} {{member.destinyUserInfo.platformName}}

--- a/src/app/clan/clan-milestones/clan-milestones.component.html
+++ b/src/app/clan/clan-milestones/clan-milestones.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="state.modelPlayer|async as modelPlayer; else loadingModel">
+<ng-container *ngIf="state.modelPlayer() as modelPlayer; else loadingModel">
 
     <div class="mobile-button-row">
         <button mat-button (click)="showAllClanMilestones()" *ngIf="hiddenClanMilestones()!.length>0">
@@ -42,7 +42,7 @@
             </tr>
         </thead>
         <tbody>
-            <tr *ngFor="let member of filteredMembers|async">
+            <tr *ngFor="let member of filteredMembers()">
                 <td class="lead">
                     <a [routerLink]="['/',member.destinyUserInfo.membershipType, member.destinyUserInfo.membershipId]">
                         {{member.destinyUserInfo.displayName}} {{member.destinyUserInfo.platformName}}

--- a/src/app/clan/clan-milestones/clan-milestones.component.ts
+++ b/src/app/clan/clan-milestones/clan-milestones.component.ts
@@ -1,12 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, signal } from '@angular/core';
 import { IconService } from '@app/service/icon.service';
 import { BungieGroupMember } from '@app/service/model';
 import { StorageService } from '@app/service/storage.service';
 import { ChildComponent } from '@app/shared/child.component';
-import { BehaviorSubject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { ClanStateService } from '../clan-state.service';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgIf, NgTemplateOutlet, NgFor, AsyncPipe } from '@angular/common';
 import { MatButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -22,19 +19,17 @@ import { MilestoneCheckComponent } from '../../shared/milestone-check/milestone-
     styleUrls: ['./clan-milestones.component.scss'],
     imports: [NgIf, MatButton, FaIconComponent, NgTemplateOutlet, NgFor, MatTooltip, RouterLink, FriendStarComponent, MilestoneCheckComponent, AsyncPipe]
 })
-export class ClanMilestonesComponent extends ChildComponent {  
-  public filteredMembers: BehaviorSubject<BungieGroupMember[]> = new BehaviorSubject<BungieGroupMember[]>([]);
+export class ClanMilestonesComponent extends ChildComponent {
+  public filteredMembers = signal<BungieGroupMember[]>([]);
 
   constructor(
     public state: ClanStateService,
     public iconService: IconService) {
     super();
-    this.state.sortedMembers.pipe(
-      takeUntilDestroyed(this.destroyRef))
-      .subscribe(
-        x => {
-          this.filterMilestones();
-        });
+    effect(() => {
+      const _members = this.state.sortedMembers();
+      this.filterMilestones();
+    });
   }
 
   
@@ -62,7 +57,7 @@ export class ClanMilestonesComponent extends ChildComponent {
       if (member!.currentPlayer()!.characters[0].milestones == null) { return false; }
       return true;
     });
-    this.filteredMembers.next(temp);
+    this.filteredMembers.set(temp);
   }
 
 }

--- a/src/app/clan/clan-settings/clan-settings.component.html
+++ b/src/app/clan/clan-settings/clan-settings.component.html
@@ -31,7 +31,7 @@
                 </mat-option>
             </mat-select>
         </mat-form-field>
-        <span class="filter-count">{{(state.sortedMembers|async)!.length}} / {{state.members.length}}</span>
+        <span class="filter-count">{{state.sortedMembers()!.length}} / {{state.members.length}}</span>
 
     </div>
 

--- a/src/app/clan/clan-settings/clan-settings.component.ts
+++ b/src/app/clan/clan-settings/clan-settings.component.ts
@@ -8,7 +8,7 @@ import { MatButton } from '@angular/material/button';
 import { MatFormField } from '@angular/material/form-field';
 import { MatSelect, MatSelectTrigger } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
-import { NgFor, AsyncPipe } from '@angular/common';
+import { NgFor } from '@angular/common';
 import { MatOption } from '@angular/material/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
@@ -17,7 +17,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
     selector: 'd2c-clan-settings',
     templateUrl: './clan-settings.component.html',
     styleUrls: ['./clan-settings.component.scss'],
-    imports: [MatButton, MatFormField, MatSelect, FormsModule, NgFor, MatOption, MatSelectTrigger, FaIconComponent, AsyncPipe]
+    imports: [MatButton, MatFormField, MatSelect, FormsModule, NgFor, MatOption, MatSelectTrigger, FaIconComponent]
 })
 export class ClanSettingsComponent extends ChildComponent {
 

--- a/src/app/clan/clan-state.service.ts
+++ b/src/app/clan/clan-state.service.ts
@@ -1,11 +1,10 @@
-import { Injectable, signal} from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { BungieService } from '@app/service/bungie.service';
 import { Sort } from '@app/service/model';
 import { StorageService } from '@app/service/storage.service';
 import { parseISO } from 'date-fns';
 import { differenceInDays } from 'date-fns/esm';
-import { BehaviorSubject } from 'rxjs';
 import { AggHistoryEntry, Badge, BungieGroupMember, ClanInfo, Const, Platform, Player, Seal, TriumphCollectibleNode, TriumphRecordNode } from '../service/model';
 
 export interface ClanUserList {
@@ -100,29 +99,29 @@ export interface ClanSearchableCollection extends ClanAggregate {
 })
 export class ClanStateService {
   public loading = signal<boolean>(false);
-  public notFound: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public notFound = signal<boolean>(false);
   public inactiveMembers: BungieGroupMember[] = [];
   public defunctMembers: BungieGroupMember[] = [];
   public id!: string;
 
-  public rawMembers: BehaviorSubject<BungieGroupMember[]> = new BehaviorSubject<BungieGroupMember[]>([]);
-  public sortedMembers: BehaviorSubject<BungieGroupMember[]> = new BehaviorSubject<BungieGroupMember[]>([]);
-  public seals: BehaviorSubject<ClanSeal[]> = new BehaviorSubject<ClanSeal[]>([]);
-  public searchableTriumphs: BehaviorSubject<ClanSearchableTriumph[]> = new BehaviorSubject<ClanSearchableTriumph[]>([]);
+  public rawMembers = signal<BungieGroupMember[]>([]);
+  public sortedMembers = signal<BungieGroupMember[]>([]);
+  public seals = signal<ClanSeal[]>([]);
+  public searchableTriumphs = signal<ClanSearchableTriumph[]>([]);
 
-  public badges: BehaviorSubject<ClanBadge[]> = new BehaviorSubject<ClanBadge[]>([]);
-  public searchableCollection: BehaviorSubject<ClanSearchableCollection[]> = new BehaviorSubject<ClanSearchableCollection[]>([]);
+  public badges = signal<ClanBadge[]>([]);
+  public searchableCollection = signal<ClanSearchableCollection[]>([]);
 
-  public trackedTriumphs: BehaviorSubject<ClanSearchableTriumph[]> = new BehaviorSubject<ClanSearchableTriumph[]>([]);
-  public aggHistory: BehaviorSubject<ClanAggHistoryEntry[]> = new BehaviorSubject<ClanAggHistoryEntry[]>([]);
-  public sweepMsg: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
-  public info: BehaviorSubject<ClanInfo | null> = new BehaviorSubject<ClanInfo | null>(null);
-  public allLoaded: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  public profilesLoaded: BehaviorSubject<number> = new BehaviorSubject(0.01);
-  public aggHistoryLoaded: BehaviorSubject<number> = new BehaviorSubject(0);
-  public aggHistoryLoadCount: BehaviorSubject<number> = new BehaviorSubject(0);
-  public aggHistoryAllLoaded: BehaviorSubject<boolean> = new BehaviorSubject(false);
-  public modelPlayer: BehaviorSubject<Player | null> = new BehaviorSubject<Player | null>(null);
+  public trackedTriumphs = signal<ClanSearchableTriumph[]>([]);
+  public aggHistory = signal<ClanAggHistoryEntry[]>([]);
+  public sweepMsg = signal<string | null>(null);
+  public info = signal<ClanInfo | null>(null);
+  public allLoaded = signal<boolean>(false);
+  public profilesLoaded = signal<number>(0.01);
+  public aggHistoryLoaded = signal<number>(0);
+  public aggHistoryLoadCount = signal<number>(0);
+  public aggHistoryAllLoaded = signal<boolean>(false);
+  public modelPlayer = signal<Player | null>(null);
   public dTrackedTriumphIds: Record<string, boolean> = {};
   public inactivityMonthThreshold = 6;
   public inactivityMonthOptions = [1, 3, 6, 12, 48];
@@ -390,7 +389,7 @@ export class ClanStateService {
     const clanSealsDict: any = {};
 
     const clanSearchableTriumphsDict: any = {};
-    for (const m of this.sortedMembers.getValue()) {
+    for (const m of this.sortedMembers()) {
       if (!m.currentPlayer()) {
         continue;
       }
@@ -470,8 +469,8 @@ export class ClanStateService {
 
       clanSeals.push(seal);
     }
-    this.seals.next(clanSeals);
-    this.searchableTriumphs.next(clanSearchableTriumphs);
+    this.seals.set(clanSeals);
+    this.searchableTriumphs.set(clanSearchableTriumphs);
     this.applyTrackedTriumphs();
   }
 
@@ -504,7 +503,7 @@ export class ClanStateService {
     const clanSearchableCollectionsDict: any = {};
 
     // loop through all clan-members to gather badges and collectibles
-    for (const m of this.sortedMembers.getValue()) {
+    for (const m of this.sortedMembers()) {
       if (!m.currentPlayer()) {
         continue;
       }
@@ -580,7 +579,7 @@ export class ClanStateService {
     // convert our dicts into arrays
     const clanBadges: ClanBadge[] = [];
     const clanSearchableCollection: ClanSearchableCollection[] = [];
-    const allMembers = this.sortedMembers.getValue();
+    const allMembers = this.sortedMembers();
     for (const key of Object.keys(clanSearchableCollectionsDict)) {
       const pushMe: ClanSearchableCollection = clanSearchableCollectionsDict[key];
       // handle secret collections
@@ -629,8 +628,8 @@ export class ClanStateService {
       }
       return 0;
     });
-    this.badges.next(clanBadges);
-    this.searchableCollection.next(clanSearchableCollection);
+    this.badges.set(clanBadges);
+    this.searchableCollection.set(clanSearchableCollection);
   }
 
 
@@ -675,7 +674,7 @@ export class ClanStateService {
   }
 
   private applyTrackedTriumphs() {
-    const triumphs = this.searchableTriumphs.getValue();
+    const triumphs = this.searchableTriumphs();
     const tempTriumphs: ClanSearchableTriumph[] = [];
     if (Object.keys(this.dTrackedTriumphIds).length > 0) {
       for (const t of triumphs) {
@@ -684,15 +683,15 @@ export class ClanStateService {
         }
       }
     }
-    this.trackedTriumphs.next(tempTriumphs);
+    this.trackedTriumphs.set(tempTriumphs);
   }
 
   private async loadClanInfo() {
     try {
       const i = await this.bungieService.getClanInfo(this.id);
-      this.info.next(i);
+      this.info.set(i);
     } catch {
-      this.notFound.next(true);
+      this.notFound.set(true);
     }
   }
 
@@ -701,26 +700,26 @@ export class ClanStateService {
       return;
     }
     this.id = id;
-    this.allLoaded.next(false);
-    this.aggHistoryAllLoaded.next(false);
-    this.aggHistory.next([]);
-    this.notFound.next(false);
+    this.allLoaded.set(false);
+    this.aggHistoryAllLoaded.set(false);
+    this.aggHistory.set([]);
+    this.notFound.set(false);
     this.loading.set(true);
     this.members = [];
 
     this.defunctMembers = [];
     this.inactiveMembers = [];
-    this.modelPlayer.next(null);
-    this.profilesLoaded.next(0.01);
-    this.aggHistoryLoaded.next(0);
-    this.aggHistoryLoadCount.next(0);
+    this.modelPlayer.set(null);
+    this.profilesLoaded.set(0.01);
+    this.aggHistoryLoaded.set(0);
+    this.aggHistoryLoadCount.set(0);
 
     try {
       // async load clan progressions etc
       this.loadClanInfo();
       // load the clan members
       const allMembers = await this.bungieService.getClanMembers(this.id);
-      this.rawMembers.next(allMembers);
+      this.rawMembers.set(allMembers);
       const functMembers = allMembers.filter(x => {
         if (x.isDefunct()) {
           this.defunctMembers.push(x);
@@ -751,11 +750,11 @@ export class ClanStateService {
       this.members = members;
       // this will filter members by platform as well
       this.sortData();
-      const operateOnMe = this.sortedMembers.getValue();
+      const operateOnMe = this.sortedMembers();
       console.log(`Active ${operateOnMe.length} / ${functMembers.length}`);
       this.loading.set(false);
       for (const t of operateOnMe) {
-        if (this.modelPlayer.getValue() == null) {
+        if (this.modelPlayer() == null) {
           await this.loadSpecificPlayer(t, false);
         } else {
           this.loadSpecificPlayer(t, false);
@@ -779,7 +778,7 @@ export class ClanStateService {
   public downloadCsvReport() {
     const sDate = new Date().toISOString().slice(0, 10);
     let sCsv = 'member,platform,chars,lastPlayed days ago,Artifact,Season Rank,Triumph Score,Trials,Glory,Gambit,Crucible,Vanguard,Weekly XP,max LL,';
-    this.modelPlayer.getValue()!.milestoneList.forEach(m => {
+    this.modelPlayer()!.milestoneList.forEach(m => {
       let tempName = m.name;
       tempName = m.name.replace(',', '_');
       sCsv += tempName + ',';
@@ -787,7 +786,7 @@ export class ClanStateService {
     });
     sCsv += '\n';
 
-    this.sortedMembers.getValue().forEach(member => {
+    this.sortedMembers().forEach(member => {
       if (member.destinyUserInfo == null) { return; }
       if (member.currentPlayer() == null) { return; }
 
@@ -839,7 +838,7 @@ export class ClanStateService {
       sCsv += member!.currentPlayer()!.maxLL + ',';
 
       if (member!.currentPlayer()!.characters != null) {
-        this.modelPlayer.getValue()!.milestoneList.forEach(mileStoneName => {
+        this.modelPlayer()!.milestoneList.forEach(mileStoneName => {
           let total = 0;
           let pctTotal = 0;
           let possible = 0;
@@ -911,9 +910,9 @@ export class ClanStateService {
       });
     }
     temp.sort(ClanStateService.generateComparator(this.sort));
-    this.sortedMembers.next(temp);
+    this.sortedMembers.set(temp);
 
-    if (this.allLoaded.getValue()) {
+    if (this.allLoaded()) {
       this.handleTriumphs();
       this.handleCollections();
     }
@@ -1090,11 +1089,11 @@ export class ClanStateService {
   // dialog
   // graph
   private async sweepAggHistory(type: string, msg: string) {
-    console.log(`Sweep agg history ${type} - ${msg}: ${this.sortedMembers.getValue().length}`);
-    this.sweepMsg.next(msg);
-    const loadAggDenom = this.sortedMembers.getValue().length;
+    console.log(`Sweep agg history ${type} - ${msg}: ${this.sortedMembers().length}`);
+    this.sweepMsg.set(msg);
+    const loadAggDenom = this.sortedMembers().length;
     let loadAggNum = 0;
-    for (const m of this.sortedMembers.getValue()) {
+    for (const m of this.sortedMembers()) {
       try {
         if (!m.currentPlayer()) {
           console.log(`    Skipping ${m.destinyUserInfo.displayName}`);
@@ -1112,22 +1111,22 @@ export class ClanStateService {
       finally {
         loadAggNum++;
         const pct = loadAggNum / loadAggDenom;
-        this.aggHistoryLoadCount.next(loadAggNum);
-        this.aggHistoryLoaded.next(pct);
+        this.aggHistoryLoadCount.set(loadAggNum);
+        this.aggHistoryLoaded.set(pct);
       }
     }
   }
 
   public async loadAggHistory() {
     // don't reload unless clan is reloaded
-    if (this.aggHistoryAllLoaded.getValue()) {
+    if (this.aggHistoryAllLoaded()) {
       return;
     }
     console.log(`Load agg history`);
     await this.sweepAggHistory('cache', 'Checking cached history info: ');
     await this.sweepAggHistory('best', 'Loading latest history info: ');
     await this.sweepAggHistory('nf', 'Checking NF high scores: ');
-    this.aggHistoryAllLoaded.next(true);
+    this.aggHistoryAllLoaded.set(true);
   }
 
   private static removePrefix(s: string, preFix: string, ignoreCase: true): string {
@@ -1143,7 +1142,7 @@ export class ClanStateService {
 
   private handleAggHistory(): void {
     const clanAggHistoryDict: { [key: string]: ClanAggHistoryEntry } = {};
-    const sortedMembers = this.sortedMembers.getValue();
+    const sortedMembers = this.sortedMembers();
     for (const m of sortedMembers) {
       if (!m.currentPlayer()) {
         continue;
@@ -1214,7 +1213,7 @@ export class ClanStateService {
       //   }
       //   return 0;
     });
-    this.aggHistory.next(clanAggHistoryEntrys);
+    this.aggHistory.set(clanAggHistoryEntrys);
   }
 
   public async loadSpecificPlayer(target: BungieGroupMember, reload: boolean): Promise<void> {
@@ -1226,7 +1225,7 @@ export class ClanStateService {
         'CharacterEquipment', 'ItemInstances', 'CharacterInventories', 'ProfileInventories',
         'CharacterActivities', 'Records', 'Collectibles', 'PresentationNodes'], true, true);
       target.player$.next(x);
-      if (this.modelPlayer.getValue() == null && x != null && x.characters != null && x.characters[0].clanMilestones != null) {
+      if (this.modelPlayer() == null && x != null && x.characters != null && x.characters[0].clanMilestones != null) {
         x.milestoneList.sort((a, b) => {
           if (a.boost.sortVal < b.boost.sortVal) { return 1; }
           if (a.boost.sortVal > b.boost.sortVal) { return -1; }
@@ -1236,7 +1235,7 @@ export class ClanStateService {
           if (a.name < b.name) { return -1; }
           return 0;
         });
-        this.modelPlayer.next(x);
+        this.modelPlayer.set(x);
       }
       if (x != null && x.characters != null) {
         // in case this is a retry
@@ -1250,12 +1249,12 @@ export class ClanStateService {
       target.errorMsg = 'Unable to load player data';
     }
 
-    const loaded = this.sortedMembers.getValue().filter(x => (x.errorMsg != null || x.currentPlayer() != null)).length;
-    const total = this.sortedMembers.getValue().length;
-    this.profilesLoaded.next(loaded / total);
+    const loaded = this.sortedMembers().filter(x => (x.errorMsg != null || x.currentPlayer() != null)).length;
+    const total = this.sortedMembers().length;
+    this.profilesLoaded.set(loaded / total);
     if (loaded >= total && total > 0) {
       console.log(`All players loaded`);
-      this.allLoaded.next(true);
+      this.allLoaded.set(true);
     }
     this.sortData();
   }

--- a/src/app/clan/clan-triumphs/clan-seals/clan-seals.component.html
+++ b/src/app/clan/clan-triumphs/clan-seals/clan-seals.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="state.seals|async as seals">
+<ng-container *ngIf="state.seals() as seals">
     <mat-accordion>
         <ng-container *ngFor="let s of seals">
             <mat-expansion-panel  (opened)="opened($any(s).hash)">

--- a/src/app/clan/clan-triumphs/clan-seals/clan-seals.component.ts
+++ b/src/app/clan/clan-triumphs/clan-seals/clan-seals.component.ts
@@ -4,7 +4,7 @@ import { ClanSeal, ClanStateService } from '@app/clan/clan-state.service';
 import { IconService } from '@app/service/icon.service';
 import { ChildComponent } from '@app/shared/child.component';
 import { ClanTriumphSealDialogComponent } from '../clan-triumph-seal-dialog/clan-triumph-seal-dialog.component';
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { NgIf, NgFor } from '@angular/common';
 import { MatAccordion, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription } from '@angular/material/expansion';
 import { MatButton } from '@angular/material/button';
 import { ClanTriumphItemComponent } from '../clan-triumph-item/clan-triumph-item.component';
@@ -14,7 +14,7 @@ import { ClanTriumphItemComponent } from '../clan-triumph-item/clan-triumph-item
     selector: 'd2c-clan-seals',
     templateUrl: './clan-seals.component.html',
     styleUrls: ['./clan-seals.component.scss'],
-    imports: [NgIf, MatAccordion, NgFor, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription, MatButton, ClanTriumphItemComponent, AsyncPipe]
+    imports: [NgIf, MatAccordion, NgFor, MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle, MatExpansionPanelDescription, MatButton, ClanTriumphItemComponent]
 })
 export class ClanSealsComponent extends ChildComponent {
   openEntryId: string|null = null;

--- a/src/app/clan/clan-triumphs/clan-triumph-search/clan-triumph-search.component.html
+++ b/src/app/clan/clan-triumphs/clan-triumph-search/clan-triumph-search.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="filteredTriumphs|async as t" class="clan-triumph-search">
+<div *ngIf="filteredTriumphs() as t" class="clan-triumph-search">
     <div class="left" class="medium-margin">
         <mat-form-field class="searchField">
             <mat-label>Wildcard Search Triumphs</mat-label>

--- a/src/app/clan/clan-triumphs/clan-triumph-search/clan-triumph-search.component.ts
+++ b/src/app/clan/clan-triumphs/clan-triumph-search/clan-triumph-search.component.ts
@@ -1,11 +1,11 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, OnInit, signal } from '@angular/core';
 import { ClanSearchableTriumph, ClanStateService } from '@app/clan/clan-state.service';
 import { ChildComponent } from '@app/shared/child.component';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 import { IconService } from '@app/service/icon.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { NgIf, NgFor } from '@angular/common';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
@@ -16,23 +16,23 @@ import { ClanTriumphItemComponent } from '../clan-triumph-item/clan-triumph-item
     selector: 'd2c-clan-triumph-search',
     templateUrl: './clan-triumph-search.component.html',
     styleUrls: ['./clan-triumph-search.component.scss'],
-    imports: [NgIf, MatFormField, MatLabel, MatInput, FormsModule, NgFor, ClanTriumphItemComponent, AsyncPipe]
+    imports: [NgIf, MatFormField, MatLabel, MatInput, FormsModule, NgFor, ClanTriumphItemComponent]
 })
 export class ClanTriumphSearchComponent extends ChildComponent implements OnInit {
   private triumphSearchSubject: Subject<void> = new Subject<void>();
   public triumphFilterText: string | null = null;
-  public filteredTriumphs: BehaviorSubject<ClanSearchableTriumph[]> = new BehaviorSubject<ClanSearchableTriumph[]>([]);
+  public filteredTriumphs = signal<ClanSearchableTriumph[]>([]);
 
   constructor(public state: ClanStateService, public iconService: IconService) {
     super();
     this.triumphFilterText = localStorage.getItem('triumph-filter');
+    effect(() => {
+      const _triumphs = this.state.searchableTriumphs();
+      this.filterTriumphs();
+    });
   }
 
   ngOnInit() {
-    this.state.searchableTriumphs.pipe(
-      takeUntilDestroyed(this.destroyRef)).subscribe(p => {
-        this.filterTriumphs();
-      });
     this.triumphSearchSubject.pipe(
       takeUntilDestroyed(this.destroyRef),
       debounceTime(50))
@@ -47,13 +47,13 @@ export class ClanTriumphSearchComponent extends ChildComponent implements OnInit
   }
 
   private filterTriumphs() {
-    const searchableTriumphs = this.state.searchableTriumphs.getValue();
+    const searchableTriumphs = this.state.searchableTriumphs();
     if (this.triumphFilterText == null || this.triumphFilterText.trim().length == 0) {
-      this.filteredTriumphs.next([]);
+      this.filteredTriumphs.set([]);
       return;
     }
     if (searchableTriumphs == null) {
-      this.filteredTriumphs.next([]);
+      this.filteredTriumphs.set([]);
       return;
     }
     const temp = [];
@@ -64,7 +64,7 @@ export class ClanTriumphSearchComponent extends ChildComponent implements OnInit
         temp.push(t);
       }
     }
-    this.filteredTriumphs.next(temp);
+    this.filteredTriumphs.set(temp);
   }
 
 }

--- a/src/app/clan/clan-triumphs/clan-triumph-tracked/clan-triumph-tracked.component.html
+++ b/src/app/clan/clan-triumphs/clan-triumph-tracked/clan-triumph-tracked.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="state.trackedTriumphs|async as t" class="clan-triumph-search">
+<div *ngIf="state.trackedTriumphs() as t" class="clan-triumph-search">
     
     <div *ngIf="t.length==0" class="left" class="medium-margin">        
             Click a star on a triumph on another tab to track it here

--- a/src/app/clan/clan-triumphs/clan-triumph-tracked/clan-triumph-tracked.component.ts
+++ b/src/app/clan/clan-triumphs/clan-triumph-tracked/clan-triumph-tracked.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ClanStateService } from '@app/clan/clan-state.service';
 import { ChildComponent } from '@app/shared/child.component';
-import { NgIf, NgFor, AsyncPipe } from '@angular/common';
+import { NgIf, NgFor } from '@angular/common';
 import { ClanTriumphItemComponent } from '../clan-triumph-item/clan-triumph-item.component';
 
 @Component({
@@ -9,7 +9,7 @@ import { ClanTriumphItemComponent } from '../clan-triumph-item/clan-triumph-item
     selector: 'd2c-clan-triumph-tracked',
     templateUrl: './clan-triumph-tracked.component.html',
     styleUrls: ['./clan-triumph-tracked.component.scss'],
-    imports: [NgIf, NgFor, ClanTriumphItemComponent, AsyncPipe]
+    imports: [NgIf, NgFor, ClanTriumphItemComponent]
 })
 export class ClanTriumphTrackedComponent extends ChildComponent {
 

--- a/src/app/clan/clan-triumphs/clan-triumphs.component.html
+++ b/src/app/clan/clan-triumphs/clan-triumphs.component.html
@@ -10,7 +10,7 @@
     </a>
 </nav>
 <mat-tab-nav-panel #tabPanel>
-  <ng-container *ngIf="state.allLoaded|async; else notLoaded">
+  <ng-container *ngIf="state.allLoaded(); else notLoaded">
       <router-outlet></router-outlet>
   </ng-container>
 </mat-tab-nav-panel>

--- a/src/app/clan/clan-triumphs/clan-triumphs.component.ts
+++ b/src/app/clan/clan-triumphs/clan-triumphs.component.ts
@@ -5,14 +5,14 @@ import { ClanStateService } from '../clan-state.service';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { NgIf, AsyncPipe } from '@angular/common';
+import { NgIf } from '@angular/common';
 
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'd2c-clan-triumphs',
     templateUrl: './clan-triumphs.component.html',
     styleUrls: ['./clan-triumphs.component.scss'],
-    imports: [MatTabNav, MatTabLink, RouterLink, RouterLinkActive, FaIconComponent, MatTabNavPanel, NgIf, RouterOutlet, AsyncPipe]
+    imports: [MatTabNav, MatTabLink, RouterLink, RouterLinkActive, FaIconComponent, MatTabNavPanel, NgIf, RouterOutlet]
 })
 export class ClanTriumphsComponent extends ChildComponent {
 

--- a/src/app/clan/clan.component.html
+++ b/src/app/clan/clan.component.html
@@ -1,12 +1,12 @@
 
-    <div *ngIf="(state.notFound|async)==false; else notFound">
+    <div *ngIf="(state.notFound())==false; else notFound">
 
       <h3 class="clan-name">
-        <ng-container *ngIf="(state.info|async)!=null">Clan: {{(state.info|async)!.name}}</ng-container>
-        <ng-container *ngIf="(state.info|async)==null"><fa-icon [icon]="iconService.farSpinner" animation="spin-pulse" [fixedWidth]="true"></fa-icon></ng-container>
+        <ng-container *ngIf="(state.info())!=null">Clan: {{(state.info())!.name}}</ng-container>
+        <ng-container *ngIf="(state.info())==null"><fa-icon [icon]="iconService.farSpinner" animation="spin-pulse" [fixedWidth]="true"></fa-icon></ng-container>
       </h3>
-      <ng-container *ngIf="(state.allLoaded|async) === false">
-        <ng-container *ngIf="state.profilesLoaded|async as pct">
+      <ng-container *ngIf="(state.allLoaded()) === false">
+        <ng-container *ngIf="state.profilesLoaded() as pct">
           <mat-progress-bar mode="determinate" [value]="pct*100"></mat-progress-bar>
         </ng-container>
       </ng-container>

--- a/src/app/clan/clan.component.ts
+++ b/src/app/clan/clan.component.ts
@@ -6,7 +6,7 @@ import { ChildComponent } from '../shared/child.component';
 import { ClanStateService } from './clan-state.service';
 import { IconService } from '@app/service/icon.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NgIf, AsyncPipe } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
@@ -19,7 +19,7 @@ import { MatAnchor } from '@angular/material/button';
     selector: 'd2c-clan-history',
     templateUrl: './clan.component.html',
     styleUrls: ['./clan.component.scss'],
-    imports: [NgIf, FaIconComponent, MatProgressBar, MatTabNav, MatTabLink, RouterLink, RouterLinkActive, MatTabNavPanel, MatProgressSpinner, RouterOutlet, MatAnchor, AsyncPipe]
+    imports: [NgIf, FaIconComponent, MatProgressBar, MatTabNav, MatTabLink, RouterLink, RouterLinkActive, MatTabNavPanel, MatProgressSpinner, RouterOutlet, MatAnchor]
 })
 export class ClanComponent extends ChildComponent implements OnInit {
   constructor(


### PR DESCRIPTION
## Summary
- Converted 17 BehaviorSubjects in `ClanStateService` to Angular signals (`signal()`)
- Updated 16 consumer components and templates across the clan feature
- Replaced `.next()` → `.set()`, `.getValue()` → `()`, removed `| async` pipe from templates
- Converted `.subscribe()` patterns in 4 child components to `effect()` with local signal state
- Removed `AsyncPipe` from 8 components that no longer need it

## Test plan
- [x] `npm run test:ci` — 254 tests pass, coverage thresholds met
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)